### PR TITLE
ensure default timezone set for dates in emails

### DIFF
--- a/apiServer/firebase/constants.js
+++ b/apiServer/firebase/constants.js
@@ -17,6 +17,8 @@ export const CHAT_STATUS_BOOKED = 'BOOKED';
 export const CHAT_STATUS_REJECTED = 'REJECTED';
 export const CHAT_STATUS_REQUESTED = 'REQUESTED';
 
+export const DEFAULT_TIMEZONE = 'Europe/Berlin';
+
 export const MAX_NUMBER_OF_CANCELLATIONS = 1;
 export const SUSPENSION_DURATION = 2629800000; // 1 month in milliseconds
 export const EVENT_DURATION = 1800000; // 30 minutes in milliseconds;

--- a/apiServer/pubsub/handlers/chats/chatBookedMessageHandler.js
+++ b/apiServer/pubsub/handlers/chats/chatBookedMessageHandler.js
@@ -1,6 +1,6 @@
 import config from '@api/config';
 import sendChatConfirmationEmail from '@api/pubsub/drivers/sendChatEmail';
-import { ENGLISH } from '@api/firebase/constants/';
+import { DEFAULT_TIMEZONE, ENGLISH } from '@api/firebase/constants/';
 
 import { formatChatDate, formatChatTime } from 'helpers/index';
 
@@ -24,7 +24,12 @@ const ChatBookedMessageHandler = ({
       : template.de.chatConfirmation;
 
   const date = formatChatDate(start, displayLanguage);
-  const time = formatChatTime({ start, end, language: displayLanguage });
+  const time = formatChatTime({
+    start,
+    end,
+    language: displayLanguage,
+    timeZone: DEFAULT_TIMEZONE,
+  });
 
   return sendConfirmationEmail({
     emails: [{ email }],

--- a/apiServer/pubsub/handlers/chats/chatCancellationMessageHandler.js
+++ b/apiServer/pubsub/handlers/chats/chatCancellationMessageHandler.js
@@ -4,6 +4,7 @@ import { GERMAN } from '@api/firebase/constants/';
 
 import { formatChatDate, formatChatTime } from 'helpers/index';
 import { ROUTE_PROFILE } from 'routes';
+import { DEFAULT_TIMEZONE } from '@api/firebase/constants';
 
 const ChatCancellationMessageHandler = ({
   sendCancellationEmail = sendChatCancellationEmail,
@@ -27,7 +28,12 @@ const ChatCancellationMessageHandler = ({
     : template.en.chatCancellation;
 
   const date = formatChatDate(start, displayLanguage);
-  const time = formatChatTime({ start, end, language: displayLanguage });
+  const time = formatChatTime({
+    start,
+    end,
+    language: displayLanguage,
+    timezone: DEFAULT_TIMEZONE,
+  });
 
   return sendCancellationEmail({
     emails: [{ email }],

--- a/apiServer/pubsub/handlers/chats/chatRequestedMessageHandler.js
+++ b/apiServer/pubsub/handlers/chats/chatRequestedMessageHandler.js
@@ -1,6 +1,6 @@
 import config from '@api/config';
 import sendChatRequestedEmail from '@api/pubsub/drivers/sendChatEmail';
-import { GERMAN } from '@api/firebase/constants/';
+import { DEFAULT_TIMEZONE, GERMAN } from '@api/firebase/constants/';
 
 import { formatChatDate, formatChatTime } from 'helpers/index';
 import { ROUTE_PROFILE } from 'routes';
@@ -28,7 +28,12 @@ const ChatRequestedMessageHandler = ({
     : template.en.chatRequest;
 
   const date = formatChatDate(start, displayLanguage);
-  const time = formatChatTime({ start, end, language: displayLanguage });
+  const time = formatChatTime({
+    start,
+    end,
+    language: displayLanguage,
+    timeZone: DEFAULT_TIMEZONE,
+  });
 
   return sendRequestedEmail({
     emails: [{ email }],

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -19,7 +19,7 @@ export const formatChatDate = (date, locale) =>
     DATE_OPTIONS,
   );
 
-export const formatChatTime = ({ start, end, language }) => {
+export const formatChatTime = ({ start, end, language, ...options }) => {
   const dateStart = new Date(start);
   const dateEnd = new Date(end);
   const locale = language === GERMAN ? DE_LOCALE : EN_LOCALE;
@@ -27,9 +27,11 @@ export const formatChatTime = ({ start, end, language }) => {
   return `${dateStart.toLocaleTimeString(locale, {
     hour: '2-digit',
     minute: '2-digit',
+    ...options,
   })} - ${dateEnd.toLocaleTimeString(locale, {
     hour: '2-digit',
     minute: '2-digit',
     timeZoneName: 'short',
+    ...options,
   })}`;
 };


### PR DESCRIPTION
[MIT-44](https://mitein.atlassian.net/browse/MIT-44)

## Problem

Dates in email communication were being displayed in UTC timezone.
This is because they are being instantiated on the "server". 

## Solution

Create the date strings using a default timezone `Europe/Berlin`

## Checklist

- [x] Added / updated tests (Unit & Integration)
- [ ] Integration tests passed on this branch
- [x] Locally tested
- [ ] Production tested (after deployment)